### PR TITLE
Sidebar alerts promo, author byline, default to city-wide view

### DIFF
--- a/pages/1_🚔Crime_Near_Your_Address.py
+++ b/pages/1_🚔Crime_Near_Your_Address.py
@@ -8,6 +8,8 @@ from utils.st_helpers import (
     get_df_group, 
     plot_crimes_by_group, 
     sidebar_filters,
+    sidebar_promo,
+    page_footer,
     get_mapbox_plot
 )
 from utils.crime_finder import find_crimes_near_address
@@ -39,7 +41,7 @@ options = get_options(todays_date=todays_date, df=df)
 # ---------------dashboard parameters / filters
 with st.sidebar.expander("⚙️ Advanced Options", expanded=False):
     years, crimes, premises = sidebar_filters(options=options)
-st.sidebar.caption("Want to say thanks? \n[Buy me a coffee ☕](https://www.buymeacoffee.com/brydon)")
+sidebar_promo()
 
 df_filtered = df[
     (df['Year'] >= years[0]) &
@@ -102,5 +104,5 @@ if submit_button:
         )
         st.plotly_chart(p, use_container_width=True)
 
-        
+page_footer()
 

--- a/pages/2_📊Compare_Neighbourhood_Crime_Rates.py
+++ b/pages/2_📊Compare_Neighbourhood_Crime_Rates.py
@@ -7,6 +7,8 @@ from utils.st_helpers import (
     get_options, 
     plot_crimes_by_group,
     sidebar_filters,
+    sidebar_promo,
+    page_footer,
     get_hood_140_to_nbhd_mapping,
     load_counties,
     load_neighbourhood_profiles
@@ -159,9 +161,10 @@ with st.sidebar.expander("⚙️ Advanced Options", expanded=False):
         index=0,
     )
     years, crimes, premises = sidebar_filters(options=options)
-st.sidebar.caption("Want to say thanks? \n[Buy me a coffee ☕](https://www.buymeacoffee.com/brydon)")
+sidebar_promo()
 
 if len(neighbourhoods) == 0:
+    page_footer()
     st.stop()
 
 # --------------filtering and transforming
@@ -201,3 +204,5 @@ plot_crimes_by_group(
     metric_col=primary_metric,
     bar_chart=True,
 )
+
+page_footer()

--- a/utils/st_helpers.py
+++ b/utils/st_helpers.py
@@ -225,6 +225,20 @@ def sidebar_filters(options):
     )
     return years, crimes, premises
 
+def sidebar_promo():
+    """Sidebar call-to-action for the real-time alerts product (torcrime.ca)."""
+    st.sidebar.caption(
+        "🔔 Get real-time crime alerts for your neighbourhood → "
+        "[torcrime.ca](https://torcrime.ca/)"
+    )
+
+def page_footer():
+    """Muted byline rendered at the bottom of each page."""
+    st.divider()
+    st.caption(
+        "Built by [Brydon Parker](https://www.linkedin.com/in/brydon-parker/)"
+    )
+
 @st.cache_data()
 def get_hood_140_to_nbhd_mapping(df):
     assert 'ID' in df.columns, 'missing "ID" column'

--- a/utils/st_helpers.py
+++ b/utils/st_helpers.py
@@ -236,7 +236,8 @@ def page_footer():
     """Muted byline rendered at the bottom of each page."""
     st.divider()
     st.caption(
-        "Built by [Brydon Parker](https://www.linkedin.com/in/brydon-parker/)"
+        "Built by [Brydon Parker](https://www.linkedin.com/in/brydon-parker/) · "
+        "[Contact Me](mailto:parkerbrydon@gmail.com)"
     )
 
 @st.cache_data()

--- a/🦝Crime_in_Your_Neighbourhood.py
+++ b/🦝Crime_in_Your_Neighbourhood.py
@@ -54,7 +54,8 @@ with col1:
         'Choose a Neighbourhood',
         ['All Neighbourhoods 🦝'] + df['Neighbourhood'].sort_values().unique().tolist(),
         index=0,  # default to city-wide view so the landing page isn't blank
-        placeholder='start typing...'
+        placeholder='start typing...',
+        help="Don't know your neighbourhood? [Look it up here](https://www.toronto.ca/city-government/data-research-maps/neighbourhoods-communities/neighbourhood-profiles/find-your-neighbourhood/#location=&lat=&lng=&zoom=)"
     )
 with col2:
     group = st.selectbox(
@@ -62,9 +63,6 @@ with col2:
         ['Crime Type', 'Premises Type', 'Offence', 'Location Type', 'Hour', 'Day of Week', 'Month'],
         index=0,
     )
-
-if neighbourhood is None:
-    st.caption("If you don't know your neighbourhood, you can look it up here: [Find Your Neighbourhood](https://www.toronto.ca/city-government/data-research-maps/neighbourhoods-communities/neighbourhood-profiles/find-your-neighbourhood/#location=&lat=&lng=&zoom=)")
 
 with st.sidebar.expander("⚙️ Advanced Options", expanded=False):
     years, crimes, premises = sidebar_filters(options=options)

--- a/🦝Crime_in_Your_Neighbourhood.py
+++ b/🦝Crime_in_Your_Neighbourhood.py
@@ -8,6 +8,8 @@ from utils.st_helpers import (
     show_metric, 
     plot_crimes_by_group, 
     sidebar_filters,
+    sidebar_promo,
+    page_footer,
     get_mapbox_plot
 )
 from PIL import Image
@@ -51,7 +53,7 @@ with col1:
     neighbourhood = st.selectbox(
         'Choose a Neighbourhood',
         ['All Neighbourhoods 🦝'] + df['Neighbourhood'].sort_values().unique().tolist(),
-        index=None,
+        index=0,  # default to city-wide view so the landing page isn't blank
         placeholder='start typing...'
     )
 with col2:
@@ -66,9 +68,10 @@ if neighbourhood is None:
 
 with st.sidebar.expander("⚙️ Advanced Options", expanded=False):
     years, crimes, premises = sidebar_filters(options=options)
-st.sidebar.caption("Want to say thanks? \n[Buy me a coffee ☕](https://www.buymeacoffee.com/brydon)")
+sidebar_promo()
 
 if neighbourhood is None:
+    page_footer()
     st.stop()
 
 # -------------helpers
@@ -151,3 +154,5 @@ if neighbourhood != 'All Neighbourhoods 🦝':
             category_orders=category_orders
         )
         st.plotly_chart(p, use_container_width=True)
+
+page_footer()


### PR DESCRIPTION
## Summary

UI polish for the dashboard, plus the previously-committed scrape-off-app work (this branch was one commit ahead of `main`, so both are included).

### UI changes (this session)
- **Sidebar:** replaced the "Buy me a coffee ☕" link with a real-time crime alerts CTA pointing to [torcrime.ca](https://torcrime.ca/). Extracted into a shared `sidebar_promo()` helper so all three pages stay in sync.
- **Footer:** added a muted byline — **Built by [Brydon Parker](https://www.linkedin.com/in/brydon-parker/) · Contact Me** (mailto). Shared `page_footer()` helper, rendered before the early `st.stop()` calls so it shows on the landing page too.
- **Default view:** the neighbourhood picker now defaults to **All Neighbourhoods 🦝** (`index=0`) so the entry page loads a city-wide view instead of a blank page. The heavy scatter map still only renders for a specific neighbourhood, so the default view stays fast.
- **Find-your-neighbourhood hint:** moved into the neighbourhood selectbox's `help` tooltip (the ⓘ icon) instead of a standalone caption — keeps the page clean.

### Included scrape-off-app work (commit `acdeb8f`)
- Vectorized scraper writing cleaned parquet in one pass
- Nightly GitHub Action publishing the parquet as a Release artifact
- Three-tier lazy data loading in `load_or_scrape_data`

## Test plan
- Ran locally via `streamlit run` — landing page loads city-wide data, sidebar shows the torcrime.ca promo, footer byline (with Contact Me) appears on all three pages including before a neighbourhood is selected, and the help tooltip surfaces the "Find Your Neighbourhood" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)