### PR TITLE
Keep nightly scrape workflow alive past 60-day inactivity disable

### DIFF
--- a/.github/workflows/scrape-crime-data.yml
+++ b/.github/workflows/scrape-crime-data.yml
@@ -32,3 +32,9 @@ jobs:
             data/cleaned_crime_data.parquet \
             --title "Crime data $(date -u +%Y-%m-%d)" \
             --notes "Auto-generated daily snapshot of Toronto MCI data."
+
+      # Keep the cron alive: GitHub disables scheduled workflows after 60 days
+      # of no commits. This pushes a tiny dummy commit only when nearing that
+      # threshold, so the daily scrape never gets auto-disabled.
+      - name: Keepalive
+        uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
## Summary

GitHub automatically disables cron-`schedule`d workflows after **60 days with no repository commits**. The nightly `scrape-crime-data` job publishes Releases but doesn't commit, so during a quiet stretch the scheduler could get silently disabled.

This adds the [`gautamkrishnar/keepalive-workflow`](https://github.com/gautamkrishnar/keepalive-workflow) action as a final step. It pushes a tiny dummy commit **only when nearing the 60-day threshold**, keeping the schedule active without cluttering history.

- Reuses the existing `contents: write` permission already on the job.
- No behaviour change to the scrape/publish steps.

## Test plan
- Workflow runs nightly (`0 6 * * *`) and on `workflow_dispatch`; the keepalive step is a no-op until activity is stale, so normal daily runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)